### PR TITLE
Add FastAPI endpoints for document processing and framework mapping

### DIFF
--- a/app/control_mapper.py
+++ b/app/control_mapper.py
@@ -1,0 +1,14 @@
+from typing import Dict, List
+
+
+def map_controls(frameworks: Dict[str, Dict[str, str]], documents: List[str]) -> Dict[str, List[str]]:
+    """Naive control mapping by substring matching of control text in documents."""
+    mapping: Dict[str, List[str]] = {name: [] for name in frameworks}
+    for name, controls in frameworks.items():
+        for control_id, control_text in controls.items():
+            for doc in documents:
+                if control_text.lower() in doc.lower():
+                    mapping[name].append(control_id)
+                    break
+    return mapping
+

--- a/app/embeddings.py
+++ b/app/embeddings.py
@@ -1,0 +1,12 @@
+from typing import List
+
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.vectorstores import FAISS
+
+
+def embed_and_store(texts: List[str]):
+    """Create embeddings for text chunks and store them in a FAISS vector store."""
+    embeddings = OpenAIEmbeddings()
+    vectorstore = FAISS.from_texts(texts, embeddings)
+    return vectorstore
+

--- a/app/framework_loader.py
+++ b/app/framework_loader.py
@@ -1,0 +1,13 @@
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+
+def load_frameworks(path: str = "database/seed_frameworks.json") -> Dict[str, Any]:
+    """Load security frameworks from a JSON seed file."""
+    file_path = Path(path)
+    if not file_path.exists():
+        return {}
+    with open(file_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+

--- a/app/ingestion.py
+++ b/app/ingestion.py
@@ -1,0 +1,20 @@
+from typing import List
+
+
+def read_file(data: bytes) -> str:
+    """Decode raw file bytes into text."""
+    return data.decode("utf-8", errors="ignore")
+
+
+def chunk_document(text: str, chunk_size: int = 500, overlap: int = 50) -> List[str]:
+    """Simple word-based chunking for documents."""
+    words = text.split()
+    chunks: List[str] = []
+    start = 0
+    while start < len(words):
+        end = start + chunk_size
+        chunk = " ".join(words[start:end])
+        chunks.append(chunk)
+        start += max(chunk_size - overlap, 1)
+    return chunks
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,77 @@
+from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import HTMLResponse
+from typing import List
+
+from .ingestion import read_file, chunk_document
+from .embeddings import embed_and_store
+from .rag_pipeline import build_rag, answer_query
+from .framework_loader import load_frameworks
+from .control_mapper import map_controls as perform_control_mapping
+from .ui import upload_form
+from . import utils
+
+app = FastAPI(title="DocuSec API")
+
+# Global state for simple proof of concept
+vectorstore = None
+rag_chain = None
+frameworks = load_frameworks()
+
+
+# Root endpoint: return API health status
+@app.get("/")
+def root() -> dict:
+    """Health check endpoint for the API."""
+    return {"status": "ok"}
+
+
+# Document ingestion endpoint: upload file, chunk, embed, build RAG
+@app.post("/ingest")
+async def ingest_document(file: UploadFile = File(...)) -> dict:
+    """Upload a document, chunk it, embed it and build the RAG pipeline."""
+    global vectorstore, rag_chain
+    text = read_file(await file.read())
+    chunks = chunk_document(text)
+    vectorstore = embed_and_store(chunks)
+    rag_chain = build_rag(vectorstore)
+    return {"chunks": len(chunks)}
+
+
+# RAG query endpoint: ask questions over ingested content
+@app.post("/query")
+async def query_rag(question: str) -> dict:
+    """Query the RAG pipeline for an answer."""
+    if rag_chain is None:
+        return {"error": "RAG pipeline not initialized"}
+    answer = answer_query(rag_chain, question)
+    return {"answer": answer}
+
+
+# Framework retrieval endpoint: list loaded security frameworks
+@app.get("/frameworks")
+def get_frameworks() -> dict:
+    """Return the loaded security frameworks."""
+    return frameworks
+
+
+# Control mapping endpoint: map text passages to framework controls
+@app.post("/map_controls")
+async def map_controls(documents: List[str]) -> dict:
+    """Map document text to controls in the loaded frameworks."""
+    mapping = perform_control_mapping(frameworks, documents)
+    return mapping
+
+
+# UI endpoint: serve HTML upload form
+@app.get("/ui/upload_form", response_class=HTMLResponse)
+def get_upload_form() -> HTMLResponse:
+    """Return a simple HTML upload form."""
+    return HTMLResponse(upload_form())
+
+
+# Utility endpoint: expose service health check
+@app.get("/utils/health")
+def utils_health() -> dict:
+    """Utility endpoint for service health."""
+    return utils.health()
+

--- a/app/rag_pipeline.py
+++ b/app/rag_pipeline.py
@@ -1,0 +1,15 @@
+from langchain.chains import RetrievalQA
+from langchain.llms import OpenAI
+
+
+def build_rag(vectorstore):
+    """Construct a RetrievalQA chain from a vector store."""
+    llm = OpenAI()
+    retriever = vectorstore.as_retriever()
+    return RetrievalQA.from_chain_type(llm=llm, retriever=retriever)
+
+
+def answer_query(chain, question: str) -> str:
+    """Run a query through the RAG chain."""
+    return chain.run(question)
+

--- a/app/ui.py
+++ b/app/ui.py
@@ -1,0 +1,9 @@
+def upload_form() -> str:
+    """Return a minimal HTML form for file uploads."""
+    return (
+        "<html><body><h1>Upload Document</h1>"
+        "<form action='/ingest' method='post' enctype='multipart/form-data'>"
+        "<input type='file' name='file'/>"
+        "<input type='submit' value='Upload'/></form></body></html>"
+    )
+

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,4 @@
+def health() -> dict:
+    """Simple health helper used by the API."""
+    return {"status": "healthy"}
+


### PR DESCRIPTION
## Summary
- add FastAPI entrypoint with document ingestion, query, framework, mapping, UI and utility endpoints
- implement ingestion, embedding, RAG pipeline, framework loader, control mapper, UI and helper modules
- document endpoint functionality with inline comments

## Testing
- `python -m py_compile app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8d314837c8328957d9f77df94e31e