### PR TITLE
Add FastAPI backend and refactor Streamlit frontend

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,0 +1,124 @@
+"""FastAPI backend exposing document ingestion and query endpoints.
+
+This module wires existing helper functions into HTTP endpoints consumed by
+the Streamlit frontend.  Each endpoint includes basic documentation and notes
+on security considerations.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from pydantic import BaseModel
+
+from app.control_mapper import map_controls
+from app.embeddings import SimpleVectorStore, build_vector_store
+from app.framework_loader import load_frameworks
+from app.ingestion import parse_document
+from app.rag_pipeline import answer_query
+
+
+app = FastAPI(title="DocuSec API")
+
+# In-memory state used for demonstration purposes only.  A production system
+# should persist data and enforce authentication/authorization.
+_chunks: List[str] = []
+_store: SimpleVectorStore | None = None
+
+
+class _UploadWrapper:
+    """Adapter giving :func:`parse_document` a sync interface.
+
+    FastAPI's :class:`~fastapi.UploadFile` exposes an async ``read`` method.
+    ``parse_document`` expects a file-like object with a synchronous ``read``
+    and ``name`` attribute.  This wrapper bridges that gap.
+    """
+
+    def __init__(self, name: str, data: bytes) -> None:
+        self.name = name
+        self._data = data
+
+    def read(self) -> bytes:  # pragma: no cover - trivial
+        return self._data
+
+
+@app.post("/ingest")
+async def ingest(files: List[UploadFile] = File(...)) -> dict:
+    """Ingest uploaded documents and build an in-memory vector store.
+
+    Created for Streamlit frontend integration.
+
+    Security considerations
+    -----------------------
+    * Assumes callers are authenticated; add proper auth before deployment.
+    * Files are processed in-memory without antivirus scanning.  Validate file
+      size and type to avoid malware or resource-exhaustion attacks.
+    * Parsed text is stored globally in-process and is not encrypted.
+    """
+
+    global _chunks, _store
+    for f in files:
+        data = await f.read()
+        wrapper = _UploadWrapper(f.filename, data)
+        _chunks.extend(parse_document(wrapper))
+    _store = build_vector_store(_chunks)
+    return {"chunks": len(_chunks)}
+
+
+@app.get("/frameworks")
+def get_frameworks() -> dict:
+    """Return the list of supported security frameworks.
+
+    Security considerations
+    -----------------------
+    * Framework data is loaded from disk without validation.  Protect the
+      underlying files from tampering and validate contents in production.
+    """
+
+    return {"frameworks": load_frameworks()}
+
+
+class MappingRequest(BaseModel):
+    framework: str
+
+
+@app.post("/map_controls")
+def map_controls_endpoint(req: MappingRequest) -> List[dict]:
+    """Map ingested document chunks to framework controls.
+
+    This endpoint was created for Streamlit functionality.
+
+    Security considerations
+    -----------------------
+    * Requires prior document ingestion; otherwise returns ``400``.
+    * Output includes raw document excerpts.  Apply access controls and scrub
+      sensitive information before exposing in production.
+    """
+
+    if not _chunks:
+        raise HTTPException(status_code=400, detail="No documents ingested")
+    return map_controls(_chunks, req.framework)
+
+
+class QueryRequest(BaseModel):
+    query: str
+
+
+@app.post("/query")
+def query_endpoint(req: QueryRequest) -> dict:
+    """Answer a user query using the previously built vector store.
+
+    This endpoint was created for Streamlit functionality.
+
+    Security considerations
+    -----------------------
+    * Returns ``400`` if no documents have been ingested.
+    * ``query`` is used verbatim in substring searches; sanitize or log
+      carefully to avoid injection and information-disclosure risks.
+    """
+
+    if _store is None:
+        raise HTTPException(status_code=400, detail="No documents ingested")
+    return {"answer": answer_query(req.query, _store)}
+

--- a/app/control_mapper.py
+++ b/app/control_mapper.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def map_controls(chunks: List[str], framework: str) -> List[Dict[str, str]]:
+    """Map document chunks to placeholder framework controls.
+
+    This helper simply pairs the first few text chunks with sequential control
+    identifiers for the selected framework.  It is intended for demonstration
+    only and does not perform any semantic analysis.
+
+    Security considerations
+    -----------------------
+    * Input data is trusted blindly.  In a real application, validate and
+      sanitize ``chunks`` to avoid inadvertently exposing sensitive
+      information.
+    * There is no authentication or authorization.  Ensure only authorized
+      users can trigger control mapping when dealing with proprietary data.
+    """
+    mappings: List[Dict[str, str]] = []
+    for idx, chunk in enumerate(chunks[:3]):
+        mappings.append({
+            "control": f"{framework}-Control-{idx + 1}",
+            "excerpt": chunk.strip(),
+        })
+    return mappings

--- a/app/embeddings.py
+++ b/app/embeddings.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class SimpleVectorStore:
+    """A lightweight in-memory vector store using substring search.
+
+    Security considerations
+    -----------------------
+    * Stored chunks are kept in plain text and in process memory; do not use
+      this implementation for sensitive or regulated data without additional
+      protections such as encryption at rest.
+    * No access control is enforced.  Ensure callers are authorized to query
+      the data contained within ``chunks``.
+    """
+
+    chunks: List[str]
+
+    def search(self, query: str, top_k: int = 3) -> List[str]:
+        """Return up to ``top_k`` chunks containing the query string.
+
+        Security considerations
+        -----------------------
+        * The search performs a simple case-insensitive substring match and
+          does not sanitize ``query``.  Validate or sanitize user-provided
+          input if it will be logged or persisted elsewhere.
+        * ``top_k`` should be bounded to prevent excessive memory usage or
+          denial-of-service scenarios.
+        """
+        results = [c for c in self.chunks if query.lower() in c.lower()]
+        return results[:top_k]
+
+
+def build_vector_store(chunks: List[str]) -> SimpleVectorStore:
+    """Create a :class:`SimpleVectorStore` from text chunks.
+
+    Security considerations
+    -----------------------
+    * Input ``chunks`` are accepted as-is.  Sanitize or strip sensitive data
+      before building the store.
+    """
+    return SimpleVectorStore(chunks=chunks)

--- a/app/framework_loader.py
+++ b/app/framework_loader.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+
+def load_frameworks() -> List[str]:
+    """Load available security frameworks from the bundled database.
+
+    The function attempts to read ``seed_frameworks.json`` from the local
+    ``database`` directory and falls back to a small hard-coded list if the
+    file is absent or invalid.
+
+    Security considerations
+    -----------------------
+    * Only files within the expected project directory are accessed, but the
+      JSON contents are trusted without validation.  In environments where the
+      file may be modified by untrusted parties, validate the schema and
+      contents to avoid loading malicious data.
+    * No authentication or access checks are performed.  Ensure that the
+      database path is not writable by unauthorized users.
+    """
+    db_path = Path(__file__).resolve().parent.parent / "database" / "seed_frameworks.json"
+    if db_path.exists() and db_path.stat().st_size > 0:
+        try:
+            with open(db_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if isinstance(data, list):
+                return data
+        except json.JSONDecodeError:
+            pass
+    return ["ISO 27001", "NIST 800-53", "SOC 2"]

--- a/app/ingestion.py
+++ b/app/ingestion.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from io import BytesIO
+from typing import List
+
+import fitz  # PyMuPDF
+from docx import Document
+
+from .utils import chunk_text
+
+
+def parse_document(uploaded_file) -> List[str]:
+    """Parse an uploaded PDF or DOCX file into text chunks.
+
+    The file contents are read into memory, converted to plain text and then
+    split using :func:`chunk_text`.
+
+    Security considerations
+    -----------------------
+    * Uploaded files are treated as untrusted input.  Only ``pdf`` and ``docx``
+      extensions are processed to reduce risk from malicious formats.
+    * No malware scanning or content validation is performed.  In production,
+      run server-side antivirus and consider file size limits to avoid
+      resource-exhaustion attacks.
+    * Parsed text is held in memory; consider user authentication and access
+      controls before exposing extracted data.
+    """
+    data = uploaded_file.read()
+    name = uploaded_file.name.lower()
+
+    text = ""
+    if name.endswith(".pdf"):
+        doc = fitz.open(stream=data, filetype="pdf")
+        for page in doc:
+            text += page.get_text()
+    elif name.endswith(".docx"):
+        doc = Document(BytesIO(data))
+        text = "\n".join(p.text for p in doc.paragraphs)
+    else:
+        raise ValueError("Unsupported file type: %s" % uploaded_file.name)
+
+    return chunk_text(text)

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import requests
+import streamlit as st
+
+# Streamlit now communicates with a FastAPI backend instead of calling helper
+# functions directly.  ``API_URL`` should point to the running backend
+# instance.  In production, protect the API with authentication and transport
+# security.
+API_URL = "http://localhost:8000"
+
+st.set_page_config(page_title="DocuSec", page_icon="📄")
+
+st.title("DocuSec Trust Center PoC")
+
+# Initialize session state
+if "chunks" not in st.session_state:
+    st.session_state.chunks = 0
+
+st.header("1. Upload Documents")
+uploaded_files = st.file_uploader(
+    "Upload security documentation (PDF or DOCX)",
+    type=["pdf", "docx"],
+    accept_multiple_files=True,
+)
+
+if uploaded_files:
+    files = [("files", (file.name, file.getvalue())) for file in uploaded_files]
+    resp = requests.post(f"{API_URL}/ingest", files=files, timeout=30)
+    if resp.ok:
+        st.session_state.chunks = resp.json().get("chunks", 0)
+        st.success(f"Loaded {st.session_state.chunks} text chunks.")
+    else:
+        st.error("Document ingestion failed")
+
+st.header("2. Framework Selection")
+framework_resp = requests.get(f"{API_URL}/frameworks", timeout=30)
+frameworks = framework_resp.json().get("frameworks", []) if framework_resp.ok else []
+selected_framework = st.selectbox("Select a control framework", frameworks)
+
+if selected_framework and st.session_state.chunks:
+    if st.button("Map Controls"):
+        map_resp = requests.post(
+            f"{API_URL}/map_controls", json={"framework": selected_framework}, timeout=30
+        )
+        if map_resp.ok:
+            mappings = map_resp.json()
+            st.subheader("Control Mappings")
+            for mapping in mappings:
+                st.markdown(f"**{mapping['control']}**: {mapping['excerpt']}")
+        else:
+            st.error("Control mapping failed")
+
+st.header("3. Query Documents")
+query = st.text_input("Ask a question about your documents")
+if st.button("Run Query") and query:
+    query_resp = requests.post(f"{API_URL}/query", json={"query": query}, timeout=30)
+    if query_resp.ok:
+        st.write(query_resp.json().get("answer", ""))
+    else:
+        st.warning("Please upload documents first.")

--- a/app/rag_pipeline.py
+++ b/app/rag_pipeline.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from .embeddings import SimpleVectorStore
+
+
+def answer_query(query: str, store: SimpleVectorStore) -> str:
+    """Return a rudimentary answer using relevant excerpts from the store.
+
+    Security considerations
+    -----------------------
+    * The function assumes callers are authorized to search the ``store``.
+      Implement authentication and access control before exposing this
+      capability to end users.
+    * ``query`` is used directly in substring searches.  Sanitize or validate
+      user input if search terms will be logged or displayed to other users.
+    """
+    matches = store.search(query)
+    if not matches:
+        return "No relevant information found."
+    joined = "\n".join(f"- {m}" for m in matches)
+    return f"Relevant excerpts:\n{joined}"

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import List
+
+
+def chunk_text(text: str, chunk_size: int = 500, overlap: int = 50) -> List[str]:
+    """Split text into overlapping chunks.
+
+    Parameters
+    ----------
+    text: str
+        Raw text to split.
+    chunk_size: int, optional
+        Size of each chunk.
+    overlap: int, optional
+        Number of characters to overlap between chunks.
+
+    Security considerations
+    -----------------------
+    * The function does not limit input size; extremely large ``text`` values
+      could exhaust memory.  Validate or cap ``chunk_size`` and input length in
+      production environments.
+    * ``text`` is processed verbatim.  Sanitize data if chunks will be
+      persisted or displayed to users to mitigate injection risks.
+    """
+    chunks: List[str] = []
+    start = 0
+    text_length = len(text)
+    while start < text_length:
+        end = start + chunk_size
+        chunks.append(text[start:end])
+        start = end - overlap
+    return chunks

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ langchain
 python-docx
 PyMuPDF
 pandas
+fastapi
+uvicorn
+requests


### PR DESCRIPTION
## Summary
- Introduce FastAPI backend with endpoints for document ingestion, framework retrieval, control mapping, and querying.
- Refactor Streamlit app to communicate with backend via HTTP requests.
- Include fastapi, uvicorn, and requests dependencies.

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8d3bad7dc8328ac6f491a7d34c18b