### PR TITLE
Add Streamlit frontend and separate API

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,0 +1,77 @@
+from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import HTMLResponse
+from typing import List
+
+from .ingestion import read_file, chunk_document
+from .embeddings import embed_and_store
+from .rag_pipeline import build_rag, answer_query
+from .framework_loader import load_frameworks
+from .control_mapper import map_controls as perform_control_mapping
+from .ui import upload_form
+from . import utils
+
+app = FastAPI(title="DocuSec API")
+
+# Global state for simple proof of concept
+vectorstore = None
+rag_chain = None
+frameworks = load_frameworks()
+
+
+# Root endpoint: return API health status
+@app.get("/")
+def root() -> dict:
+    """Health check endpoint for the API."""
+    return {"status": "ok"}
+
+
+# Document ingestion endpoint: upload file, chunk, embed, build RAG
+@app.post("/ingest")
+async def ingest_document(file: UploadFile = File(...)) -> dict:
+    """Upload a document, chunk it, embed it and build the RAG pipeline."""
+    global vectorstore, rag_chain
+    text = read_file(await file.read())
+    chunks = chunk_document(text)
+    vectorstore = embed_and_store(chunks)
+    rag_chain = build_rag(vectorstore)
+    return {"chunks": len(chunks)}
+
+
+# RAG query endpoint: ask questions over ingested content
+@app.post("/query")
+async def query_rag(question: str) -> dict:
+    """Query the RAG pipeline for an answer."""
+    if rag_chain is None:
+        return {"error": "RAG pipeline not initialized"}
+    answer = answer_query(rag_chain, question)
+    return {"answer": answer}
+
+
+# Framework retrieval endpoint: list loaded security frameworks
+@app.get("/frameworks")
+def get_frameworks() -> dict:
+    """Return the loaded security frameworks."""
+    return frameworks
+
+
+# Control mapping endpoint: map text passages to framework controls
+@app.post("/map_controls")
+async def map_controls(documents: List[str]) -> dict:
+    """Map document text to controls in the loaded frameworks."""
+    mapping = perform_control_mapping(frameworks, documents)
+    return mapping
+
+
+# UI endpoint: serve HTML upload form
+@app.get("/ui/upload_form", response_class=HTMLResponse)
+def get_upload_form() -> HTMLResponse:
+    """Return a simple HTML upload form."""
+    return HTMLResponse(upload_form())
+
+
+# Utility endpoint: expose service health check
+@app.get("/utils/health")
+def utils_health() -> dict:
+    """Utility endpoint for service health."""
+    return utils.health()
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,77 +1,56 @@
-from fastapi import FastAPI, UploadFile, File
-from fastapi.responses import HTMLResponse
-from typing import List
+import streamlit as st
+from ingestion import read_file, chunk_document
+from embeddings import embed_and_store
+from rag_pipeline import build_rag, answer_query
+from framework_loader import load_frameworks
+from control_mapper import map_controls as perform_control_mapping
 
-from .ingestion import read_file, chunk_document
-from .embeddings import embed_and_store
-from .rag_pipeline import build_rag, answer_query
-from .framework_loader import load_frameworks
-from .control_mapper import map_controls as perform_control_mapping
-from .ui import upload_form
-from . import utils
+# Streamlit frontend reusing core FastAPI logic
+# This app leverages existing ingestion, RAG, and control mapping functions.
 
-app = FastAPI(title="DocuSec API")
+# Initialize session state
+if "vectorstore" not in st.session_state:
+    st.session_state.vectorstore = None
+if "rag_chain" not in st.session_state:
+    st.session_state.rag_chain = None
+if "frameworks" not in st.session_state:
+    st.session_state.frameworks = load_frameworks()
 
-# Global state for simple proof of concept
-vectorstore = None
-rag_chain = None
-frameworks = load_frameworks()
+st.title("DocuSec")
 
+st.sidebar.title("Navigation")
+page = st.sidebar.radio("Go to", ["Ingest Document", "Ask Question", "Frameworks", "Map Controls"])
 
-# Root endpoint: return API health status
-@app.get("/")
-def root() -> dict:
-    """Health check endpoint for the API."""
-    return {"status": "ok"}
+if page == "Ingest Document":
+    st.header("Upload Document")
+    uploaded_file = st.file_uploader("Upload a document", type=["pdf", "docx", "txt"])
+    if uploaded_file is not None:
+        text = read_file(uploaded_file.read())
+        chunks = chunk_document(text)
+        st.session_state.vectorstore = embed_and_store(chunks)
+        st.session_state.rag_chain = build_rag(st.session_state.vectorstore)
+        st.success(f"Document ingested with {len(chunks)} chunks.")
 
+elif page == "Ask Question":
+    st.header("Ask a Question")
+    if st.session_state.rag_chain is None:
+        st.info("Please ingest a document first.")
+    else:
+        question = st.text_input("Enter your question")
+        if question:
+            answer = answer_query(st.session_state.rag_chain, question)
+            st.write(answer)
 
-# Document ingestion endpoint: upload file, chunk, embed, build RAG
-@app.post("/ingest")
-async def ingest_document(file: UploadFile = File(...)) -> dict:
-    """Upload a document, chunk it, embed it and build the RAG pipeline."""
-    global vectorstore, rag_chain
-    text = read_file(await file.read())
-    chunks = chunk_document(text)
-    vectorstore = embed_and_store(chunks)
-    rag_chain = build_rag(vectorstore)
-    return {"chunks": len(chunks)}
+elif page == "Frameworks":
+    st.header("Loaded Frameworks")
+    st.json(st.session_state.frameworks)
 
-
-# RAG query endpoint: ask questions over ingested content
-@app.post("/query")
-async def query_rag(question: str) -> dict:
-    """Query the RAG pipeline for an answer."""
-    if rag_chain is None:
-        return {"error": "RAG pipeline not initialized"}
-    answer = answer_query(rag_chain, question)
-    return {"answer": answer}
-
-
-# Framework retrieval endpoint: list loaded security frameworks
-@app.get("/frameworks")
-def get_frameworks() -> dict:
-    """Return the loaded security frameworks."""
-    return frameworks
-
-
-# Control mapping endpoint: map text passages to framework controls
-@app.post("/map_controls")
-async def map_controls(documents: List[str]) -> dict:
-    """Map document text to controls in the loaded frameworks."""
-    mapping = perform_control_mapping(frameworks, documents)
-    return mapping
-
-
-# UI endpoint: serve HTML upload form
-@app.get("/ui/upload_form", response_class=HTMLResponse)
-def get_upload_form() -> HTMLResponse:
-    """Return a simple HTML upload form."""
-    return HTMLResponse(upload_form())
-
-
-# Utility endpoint: expose service health check
-@app.get("/utils/health")
-def utils_health() -> dict:
-    """Utility endpoint for service health."""
-    return utils.health()
-
+elif page == "Map Controls":
+    st.header("Map Text to Framework Controls")
+    text_input = st.text_area("Enter text to map to controls")
+    if st.button("Map Controls"):
+        if text_input:
+            mapping = perform_control_mapping(st.session_state.frameworks, [text_input])
+            st.json(mapping)
+        else:
+            st.warning("Please provide text to map.")


### PR DESCRIPTION
## Summary
- Introduce Streamlit app as user-facing frontend that reuses ingestion, RAG, and control mapping logic
- Move FastAPI endpoints to dedicated `api.py` for backend functionality

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ab587360b4832884e881b9d212d0b1