### PR TITLE
Handle invalid JSON in framework loader

### DIFF
--- a/app/framework_loader.py
+++ b/app/framework_loader.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from pathlib import Path
 from typing import Dict, Any
 
@@ -9,5 +10,9 @@ def load_frameworks(path: str = "database/seed_frameworks.json") -> Dict[str, An
     if not file_path.exists():
         return {}
     with open(file_path, "r", encoding="utf-8") as f:
-        return json.load(f)
+        try:
+            return json.load(f)
+        except json.JSONDecodeError:
+            logging.warning("Invalid JSON in %s; returning empty dictionary.", file_path)
+            return {}
 

--- a/tests/test_framework_loader.py
+++ b/tests/test_framework_loader.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from app.framework_loader import load_frameworks
+
+
+def test_load_frameworks_empty_file(tmp_path):
+    empty_seed = tmp_path / "seed_frameworks.json"
+    empty_seed.write_text("")
+
+    result = load_frameworks(str(empty_seed))
+
+    assert result == {}


### PR DESCRIPTION
## Summary
- prevent `json.load` failures by catching `JSONDecodeError` and returning an empty dict
- add test to ensure empty `seed_frameworks.json` is handled without error

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab629a1a708328895d5732679538ab