### PR TITLE
Add CSV upload for control frameworks

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -78,16 +78,20 @@ def store_csv_in_db(file_bytes: bytes, db_path: str = DB_PATH) -> int:
     Returns:
         Number of controls stored.
     """
-    reader = csv.DictReader(io.StringIO(file_bytes.decode("utf-8")))
-    rows: List[Dict[str, str]] = []
+    reader = csv.DictReader(io.StringIO(file_bytes.decode("utf-8-sig")))
     required = {"framework_title", "control_number", "control_language"}
+    headers = set(reader.fieldnames or [])
+    if not required.issubset(headers):
+        expected = ", ".join(sorted(required))
+        raise ValueError(f"CSV headers must include: {expected}")
+
+    rows: List[Dict[str, str]] = []
     for row in reader:
-        if required.issubset(row.keys()):
-            rows.append(
-                {
-                    "framework_title": row["framework_title"],
-                    "control_number": row["control_number"],
-                    "control_language": row["control_language"],
-                }
-            )
+        rows.append(
+            {
+                "framework_title": row["framework_title"],
+                "control_number": row["control_number"],
+                "control_language": row["control_language"],
+            }
+        )
     return insert_controls(rows, db_path=db_path)

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,93 @@
+import csv
+import io
+import sqlite3
+from typing import Dict, Iterable, List
+
+DB_PATH = "database/frameworks.db"
+
+
+def _init_db(conn: sqlite3.Connection) -> None:
+    """Ensure the frameworks table exists."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS frameworks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            framework_title TEXT NOT NULL,
+            control_number TEXT NOT NULL,
+            control_language TEXT NOT NULL
+        )
+        """
+    )
+
+
+def insert_controls(rows: Iterable[Dict[str, str]], db_path: str = DB_PATH) -> int:
+    """Insert multiple control rows into the database.
+
+    Args:
+        rows: Iterable of dictionaries with framework data.
+        db_path: Optional path to the SQLite database file.
+    Returns:
+        Number of inserted rows.
+    """
+    rows = list(rows)
+    if not rows:
+        return 0
+    conn = sqlite3.connect(db_path)
+    _init_db(conn)
+    with conn:
+        conn.executemany(
+            "INSERT INTO frameworks (framework_title, control_number, control_language) VALUES (?, ?, ?)",
+            [
+                (
+                    row["framework_title"],
+                    row["control_number"],
+                    row["control_language"],
+                )
+                for row in rows
+            ],
+        )
+    conn.close()
+    return len(rows)
+
+
+def fetch_controls(db_path: str = DB_PATH) -> List[Dict[str, str]]:
+    """Retrieve all stored framework controls."""
+    conn = sqlite3.connect(db_path)
+    _init_db(conn)
+    cursor = conn.execute(
+        "SELECT framework_title, control_number, control_language FROM frameworks"
+    )
+    data = [
+        {
+            "framework_title": ft,
+            "control_number": cn,
+            "control_language": cl,
+        }
+        for ft, cn, cl in cursor.fetchall()
+    ]
+    conn.close()
+    return data
+
+
+def store_csv_in_db(file_bytes: bytes, db_path: str = DB_PATH) -> int:
+    """Parse CSV bytes and store the contents into the database.
+
+    Args:
+        file_bytes: Raw CSV file content.
+        db_path: Optional path to database file.
+    Returns:
+        Number of controls stored.
+    """
+    reader = csv.DictReader(io.StringIO(file_bytes.decode("utf-8")))
+    rows: List[Dict[str, str]] = []
+    required = {"framework_title", "control_number", "control_language"}
+    for row in reader:
+        if required.issubset(row.keys()):
+            rows.append(
+                {
+                    "framework_title": row["framework_title"],
+                    "control_number": row["control_number"],
+                    "control_language": row["control_language"],
+                }
+            )
+    return insert_controls(rows, db_path=db_path)

--- a/app/main.py
+++ b/app/main.py
@@ -56,6 +56,8 @@ elif page == "Control Frameworks":
         try:
             count = store_csv_in_db(uploaded_csv.getvalue())
             st.success(f"Stored {count} controls.")
+        except ValueError as err:
+            st.warning(str(err))
         except Exception as err:
             st.error(f"Failed to process CSV: {err}")
         st.json(fetch_controls())

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from embeddings import embed_and_store
 from rag_pipeline import build_rag, answer_query
 from framework_loader import load_frameworks
 from control_mapper import map_controls as perform_control_mapping
+from db import fetch_controls, store_csv_in_db
 
 # Streamlit frontend reusing core FastAPI logic
 # This app leverages existing ingestion, RAG, and control mapping functions.
@@ -46,7 +47,18 @@ elif page == "Interrogate Policy":
 
 elif page == "Control Frameworks":
     st.header("Loaded Frameworks")
-    st.json(st.session_state.frameworks)
+    st.json(fetch_controls())
+
+    uploaded_csv = st.file_uploader(
+        "Upload a framework CSV", type=["csv"]
+    )
+    if uploaded_csv is not None and st.button("Upload CSV"):
+        try:
+            count = store_csv_in_db(uploaded_csv.getvalue())
+            st.success(f"Stored {count} controls.")
+        except Exception as err:
+            st.error(f"Failed to process CSV: {err}")
+        st.json(fetch_controls())
 
 elif page == "Map Controls":
     st.header("Map Text to Framework Controls")

--- a/tests/test_csv_upload.py
+++ b/tests/test_csv_upload.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+import pytest
 
 # Ensure application modules are importable
 sys.path.append(str(Path(__file__).resolve().parent.parent))
@@ -29,3 +30,14 @@ def test_store_csv_and_fetch(tmp_path):
             "control_language": "Another control",
         },
     ]
+
+
+def test_store_csv_invalid_headers(tmp_path):
+    csv_content = (
+        "framework,control_number,control_language\n"
+        "ISO,1,Policy statement\n"
+    )
+    db_path = tmp_path / "frameworks.db"
+    with pytest.raises(ValueError) as err:
+        store_csv_in_db(csv_content.encode("utf-8"), db_path=str(db_path))
+    assert "framework_title" in str(err.value)

--- a/tests/test_csv_upload.py
+++ b/tests/test_csv_upload.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+# Ensure application modules are importable
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app.db import fetch_controls, store_csv_in_db
+
+
+def test_store_csv_and_fetch(tmp_path):
+    csv_content = (
+        "framework_title,control_number,control_language\n"
+        "ISO,1,Policy statement\n"
+        "ISO,2,Another control\n"
+    )
+    db_path = tmp_path / "frameworks.db"
+    inserted = store_csv_in_db(csv_content.encode("utf-8"), db_path=str(db_path))
+    assert inserted == 2
+    data = fetch_controls(db_path=str(db_path))
+    assert data == [
+        {
+            "framework_title": "ISO",
+            "control_number": "1",
+            "control_language": "Policy statement",
+        },
+        {
+            "framework_title": "ISO",
+            "control_number": "2",
+            "control_language": "Another control",
+        },
+    ]


### PR DESCRIPTION
## Summary
- allow Control Frameworks page to upload CSVs and persist controls
- add SQLite helpers for storing and retrieving framework data
- test CSV upload persistence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aba2cfb050832888418c626e3c285f