### PR TITLE
Improve policy chunking and metadata in RAG pipeline

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -31,8 +31,8 @@ async def ingest_document(file: UploadFile = File(...)) -> dict:
     """Upload a document, chunk it, embed it and build the RAG pipeline."""
     global vectorstore, rag_chain
     text = read_file(await file.read())
-    chunks = chunk_document(text)
-    vectorstore = embed_and_store(chunks)
+    chunks, metadatas = chunk_document(text)
+    vectorstore = embed_and_store(chunks, metadatas)
     rag_chain = build_rag(vectorstore)
     return {"chunks": len(chunks)}
 

--- a/app/main.py
+++ b/app/main.py
@@ -27,8 +27,8 @@ if page == "Ingest Policy Document":
     uploaded_file = st.file_uploader("Upload a document", type=["pdf", "docx", "txt"])
     if uploaded_file is not None:
         text = read_file(uploaded_file.read())
-        chunks = chunk_document(text)
-        st.session_state.vectorstore = embed_and_store(chunks)
+        chunks, metadatas = chunk_document(text)
+        st.session_state.vectorstore = embed_and_store(chunks, metadatas)
         st.session_state.rag_chain = build_rag(st.session_state.vectorstore)
         st.success(f"Document ingested with {len(chunks)} chunks.")
 

--- a/tests/test_policy_chunking.py
+++ b/tests/test_policy_chunking.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from app.ingestion import chunk_document
+
+
+def test_chunk_document_splits_policies_into_paragraphs():
+    text = (
+        "Privacy Policy\nParagraph A1.\n\nParagraph A2.\n"
+        "Security Policy\nParagraph B1."
+    )
+    chunks, metadatas = chunk_document(text, chunk_size=1000)
+    assert chunks == [
+        "Privacy Policy\n\nParagraph A1.",
+        "Privacy Policy\n\nParagraph A2.",
+        "Security Policy\n\nParagraph B1.",
+    ]
+    assert metadatas == [
+        {"policy": "Privacy Policy"},
+        {"policy": "Privacy Policy"},
+        {"policy": "Security Policy"},
+    ]

--- a/tests/test_rag_api.py
+++ b/tests/test_rag_api.py
@@ -58,7 +58,7 @@ def test_rag_query_returns_answer_within_token_limit(monkeypatch):
     def dummy_build_rag(_vectorstore):
         return DummyChain()
 
-    def dummy_embed_and_store(_chunks):
+    def dummy_embed_and_store(_chunks, _metadatas=None):
         class _Store:
             def as_retriever(self, search_kwargs=None):  # noqa: D401, ANN001
                 return self


### PR DESCRIPTION
## Summary
- chunk policy documents into policy- and paragraph-level sections
- attach policy title metadata to each chunk during embedding
- test chunking logic and update RAG ingestion for metadata-aware storage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac7fb047fc8328bb7ec04534d75070