### PR TITLE
Add framework coverage analysis view

### DIFF
--- a/app/control_mapper.py
+++ b/app/control_mapper.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Any
 
 
 def map_controls(frameworks: Dict[str, Dict[str, str]], documents: List[str]) -> Dict[str, List[str]]:
@@ -11,4 +11,46 @@ def map_controls(frameworks: Dict[str, Dict[str, str]], documents: List[str]) ->
                     mapping[name].append(control_id)
                     break
     return mapping
+
+
+def check_framework_coverage(
+    vectorstore: Any,
+    controls: List[Dict[str, str]],
+    k: int = 4,
+) -> List[Dict[str, Any]]:
+    """Return policy excerpts that may satisfy each control's requirements.
+
+    Args:
+        vectorstore: Vector store containing policy document embeddings.
+        controls: List of control dictionaries belonging to a framework.
+        k: Number of similar chunks to retrieve for each control.
+
+    Returns:
+        A list where each item represents a control with possible policy
+        excerpts that address it. Each item contains the ``framework_title``,
+        ``control_number``, ``control_language`` and a list of
+        ``policy_excerpts`` strings.
+    """
+
+    results: List[Dict[str, Any]] = []
+    for control in controls:
+        excerpts: List[str] = []
+        if vectorstore is not None:
+            try:
+                docs = vectorstore.similarity_search(
+                    control["control_language"], k=k
+                )
+                excerpts = [doc.page_content for doc in docs]
+            except Exception:
+                excerpts = []
+        results.append(
+            {
+                "framework_title": control["framework_title"],
+                "control_number": control["control_number"],
+                "control_language": control["control_language"],
+                "policy_excerpts": excerpts,
+            }
+        )
+    return results
+
 

--- a/tests/test_framework_coverage.py
+++ b/tests/test_framework_coverage.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+# Ensure application modules are importable
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app.control_mapper import check_framework_coverage
+
+
+class DummyDoc:
+    def __init__(self, content: str) -> None:
+        self.page_content = content
+
+
+class DummyStore:
+    def __init__(self) -> None:
+        self.queries = []
+
+    def similarity_search(self, query: str, k: int = 4):
+        self.queries.append((query, k))
+        return [DummyDoc(f"match: {query}")]
+
+
+def test_check_framework_coverage():
+    store = DummyStore()
+    controls = [
+        {
+            "framework_title": "ISO",
+            "control_number": "1",
+            "control_language": "Requirement text",
+        }
+    ]
+    results = check_framework_coverage(store, controls, k=1)
+    assert results == [
+        {
+            "framework_title": "ISO",
+            "control_number": "1",
+            "control_language": "Requirement text",
+            "policy_excerpts": ["match: Requirement text"],
+        }
+    ]
+    assert store.queries == [("Requirement text", 1)]


### PR DESCRIPTION
## Summary
- replace Map Controls with Framework Coverage view
- allow selecting a compliance framework and checking policy coverage
- implement coverage utility and test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac83145e8c83289173a0ddbca152ee