### PR TITLE
Enable policy persistence and selection in coverage

### DIFF
--- a/app/embeddings.py
+++ b/app/embeddings.py
@@ -1,4 +1,5 @@
 from typing import List, Dict, Any
+from pathlib import Path
 
 try:  # pragma: no cover - optional community dependency
     from langchain.embeddings import OpenAIEmbeddings
@@ -6,6 +7,8 @@ try:  # pragma: no cover - optional community dependency
 except Exception:  # pragma: no cover - executed only when packages missing
     OpenAIEmbeddings = None  # type: ignore[assignment]
     FAISS = None  # type: ignore[assignment]
+
+VECTORSTORE_DIR = Path("vector_store")
 
 
 def embed_and_store(texts: List[str], metadatas: List[Dict[str, Any]] | None = None):
@@ -25,4 +28,43 @@ def embed_and_store(texts: List[str], metadatas: List[Dict[str, Any]] | None = N
     embeddings = OpenAIEmbeddings()
     vectorstore = FAISS.from_texts(texts, embeddings, metadatas=metadatas)
     return vectorstore
+
+
+def save_vectorstore(
+    vectorstore: Any, name: str, base_dir: Path | str = VECTORSTORE_DIR
+) -> None:
+    """Persist a vector store to disk under a given name.
+
+    Args:
+        vectorstore: The FAISS vector store instance to persist.
+        name: Identifier for the stored policy.
+        base_dir: Directory where policy vector stores are maintained.
+    """
+
+    path = Path(base_dir) / name
+    path.mkdir(parents=True, exist_ok=True)
+    vectorstore.save_local(str(path))
+
+
+def list_vectorstores(base_dir: Path | str = VECTORSTORE_DIR) -> List[str]:
+    """Return a sorted list of stored policy vector store names."""
+
+    path = Path(base_dir)
+    if not path.exists():
+        return []
+    return sorted([p.name for p in path.iterdir() if p.is_dir()])
+
+
+def load_vectorstore(name: str, base_dir: Path | str = VECTORSTORE_DIR):
+    """Load a previously saved vector store by name."""
+
+    if OpenAIEmbeddings is None or FAISS is None:
+        raise ImportError(
+            "LangChain community embeddings/vectorstores are unavailable"
+        )
+    path = Path(base_dir) / name
+    embeddings = OpenAIEmbeddings()
+    return FAISS.load_local(
+        str(path), embeddings, allow_dangerous_deserialization=True
+    )
 

--- a/tests/test_vectorstore_persistence.py
+++ b/tests/test_vectorstore_persistence.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from app.embeddings import save_vectorstore, list_vectorstores
+
+
+class DummyStore:
+    def __init__(self):
+        self.saved = None
+
+    def save_local(self, path: str) -> None:  # pragma: no cover - behaves like FAISS
+        Path(path).mkdir(parents=True, exist_ok=True)
+        self.saved = path
+
+
+def test_save_and_list_vectorstores(tmp_path: Path):
+    store = DummyStore()
+    save_vectorstore(store, "PolicyA", base_dir=tmp_path)
+    assert store.saved == str(tmp_path / "PolicyA")
+    assert list_vectorstores(base_dir=tmp_path) == ["PolicyA"]


### PR DESCRIPTION
## Summary
- persist ingested policies as named FAISS vector stores
- allow choosing a stored policy when checking framework coverage
- add helpers and tests for listing/saving vector stores

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68acb1034ca083289ca6b493f07e193d