### PR TITLE
Fix coverage table to show policy text

### DIFF
--- a/app/control_mapper.py
+++ b/app/control_mapper.py
@@ -32,6 +32,18 @@ def check_framework_coverage(
         ``policy_excerpts`` strings.
     """
 
+    def _get_text(doc: Any) -> str:
+        """Return the most human readable text from a retrieved document."""
+
+        text = getattr(doc, "page_content", "") or ""
+        if not text and hasattr(doc, "metadata"):
+            meta = getattr(doc, "metadata") or {}
+            if isinstance(meta, dict):
+                text = meta.get("text", "") or meta.get("page_content", "")
+        if not isinstance(text, str):  # Fallback to string representation
+            text = str(text)
+        return text
+
     results: List[Dict[str, Any]] = []
     for control in controls:
         excerpts: List[str] = []
@@ -40,7 +52,7 @@ def check_framework_coverage(
                 docs = vectorstore.similarity_search(
                     control["control_language"], k=k
                 )
-                excerpts = [doc.page_content for doc in docs]
+                excerpts = [_get_text(doc) for doc in docs]
             except Exception:
                 excerpts = []
         results.append(

--- a/tests/test_framework_coverage.py
+++ b/tests/test_framework_coverage.py
@@ -40,3 +40,32 @@ def test_check_framework_coverage():
         }
     ]
     assert store.queries == [("Requirement text", 1)]
+
+
+class DummyMetaDoc:
+    def __init__(self, metadata):
+        self.page_content = ""
+        self.metadata = metadata
+
+
+class DummyMetaStore:
+    def __init__(self) -> None:
+        self.queries = []
+
+    def similarity_search(self, query: str, k: int = 4):
+        self.queries.append((query, k))
+        return [DummyMetaDoc({"text": f"text for {query}"})]
+
+
+def test_check_framework_coverage_metadata_text():
+    store = DummyMetaStore()
+    controls = [
+        {
+            "framework_title": "ISO",
+            "control_number": "1",
+            "control_language": "Requirement text",
+        }
+    ]
+    results = check_framework_coverage(store, controls, k=1)
+    assert results[0]["policy_excerpts"] == ["text for Requirement text"]
+    assert store.queries == [("Requirement text", 1)]


### PR DESCRIPTION
## Summary
- ensure framework coverage uses plain language text from retrieved documents
- add tests verifying metadata text fallback for policy excerpts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acb2d8952483289d901bd402a24b5f