### PR TITLE
Add LangSmith telemetry to OpenAI calls

### DIFF
--- a/app/embeddings.py
+++ b/app/embeddings.py
@@ -1,6 +1,8 @@
 from typing import List, Dict, Any
 from pathlib import Path
 
+from .utils import trace
+
 try:  # pragma: no cover - optional community dependency
     from langchain.embeddings import OpenAIEmbeddings
     from langchain.vectorstores import FAISS
@@ -25,8 +27,12 @@ def embed_and_store(texts: List[str], metadatas: List[Dict[str, Any]] | None = N
     """
     if OpenAIEmbeddings is None or FAISS is None:
         raise ImportError("LangChain community embeddings/vectorstores are unavailable")
-    embeddings = OpenAIEmbeddings()
-    vectorstore = FAISS.from_texts(texts, embeddings, metadatas=metadatas)
+    with trace(
+        "embeddings.embed_and_store",
+        inputs={"texts": texts, "metadatas": metadatas},
+    ):
+        embeddings = OpenAIEmbeddings()
+        vectorstore = FAISS.from_texts(texts, embeddings, metadatas=metadatas)
     return vectorstore
 
 

--- a/app/rag_pipeline.py
+++ b/app/rag_pipeline.py
@@ -1,6 +1,7 @@
 """Utilities for building and querying a Retrieval Augmented Generation chain."""
 
 from langchain.chains import RetrievalQA
+from .utils import trace
 
 # ChatOpenAI lives in the ``langchain_community`` package.  In minimal
 # environments this dependency may be missing, so we fall back to a very small
@@ -31,5 +32,6 @@ def build_rag(vectorstore):
 
 def answer_query(chain, question: str) -> str:
     """Run a query through the RAG chain."""
-    return chain.run(question)
+    with trace("rag_pipeline.answer_query", inputs={"question": question}):
+        return chain.run(question)
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,3 +1,13 @@
+from contextlib import contextmanager
+
+try:  # pragma: no cover - optional dependency
+    from langsmith.run_helpers import trace  # type: ignore[import]
+except Exception:  # pragma: no cover - executed when langsmith missing
+    @contextmanager
+    def trace(_: str, **__: object):  # type: ignore[override]
+        yield
+
+
 def health() -> dict:
     """Simple health helper used by the API."""
     return {"status": "healthy"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pandas
 langchain-community
 fastapi
 tiktoken
+langsmith


### PR DESCRIPTION
## Summary
- instrument OpenAI Chat and embedding operations with LangSmith `trace` context manager
- provide no-op fallback when LangSmith is unavailable
- include LangSmith package in requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acc94a636083289dea62fd4525e810