### PR TITLE
Normalize policy text encoding before vector storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Designed for development in **GitHub Codespaces** using **Python 3.10+**, **Stre
 
 ## 🎯 Key Features
 
-- ✅ Upload and parse policy documents (PDF, DOCX, TXT)
+- ✅ Upload and parse policy documents (PDF, DOCX, TXT) with automatic encoding normalization
 - ✅ Embed and persist policy content in FAISS vector stores
 - ✅ Load and extend security frameworks stored in SQLite
 - ✅ Build framework vector stores and check policy coverage

--- a/app/ingestion.py
+++ b/app/ingestion.py
@@ -5,9 +5,29 @@ from typing import Callable, Dict, List, Tuple
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 import re
 
+try:  # pragma: no cover - optional dependency
+    from charset_normalizer import from_bytes
+except Exception:  # pragma: no cover - library may be absent
+    from_bytes = None
+
 
 def read_file(data: bytes) -> str:
-    """Decode raw file bytes into text."""
+    """Decode raw file bytes into text using detected encoding.
+
+    The function attempts to detect the correct encoding of ``data`` using
+    :mod:`charset_normalizer`.  If detection fails or the library is not
+    available, the bytes are decoded as UTF-8 with errors ignored.  The
+    resulting string is always valid Unicode suitable for storing in the
+    vector store.
+    """
+
+    if from_bytes is not None:
+        try:
+            result = from_bytes(data).best()
+            if result is not None:
+                return str(result)
+        except Exception:
+            pass
     return data.decode("utf-8", errors="ignore")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ langchain-community
 fastapi
 tiktoken
 langsmith
+charset-normalizer

--- a/tests/test_encoding_normalization.py
+++ b/tests/test_encoding_normalization.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from app.ingestion import read_file
+
+
+def test_read_file_detects_cp1252_encoding():
+    text = "Smart quotes: “Hello” and euro sign €"
+    data = text.encode("cp1252")
+    assert read_file(data) == text


### PR DESCRIPTION
## Summary
- Decode uploaded policy bytes with charset-normalizer before ingestion
- Add charset-normalizer dependency
- Test encoding normalization with CP1252 sample
- Document automatic encoding normalization in key features

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acce6827e48328976d596cfbc1b765