### PR TITLE
Disable dangerous deserialization in vector store loading

### DIFF
--- a/app/embeddings.py
+++ b/app/embeddings.py
@@ -70,7 +70,9 @@ def load_vectorstore(name: str, base_dir: Path | str = VECTORSTORE_DIR):
         )
     path = Path(base_dir) / name
     embeddings = OpenAIEmbeddings()
+    # Explicitly disable dangerous deserialization to avoid executing
+    # arbitrary code when loading persisted vector stores.
     return FAISS.load_local(
-        str(path), embeddings, allow_dangerous_deserialization=True
+        str(path), embeddings, allow_dangerous_deserialization=False
     )
 


### PR DESCRIPTION
## Summary
- avoid potentially dangerous deserialization when loading FAISS vector stores

## Testing
- `pytest -q` *(fails: DID NOT RAISE <class 'ValueError'>)*

------
https://chatgpt.com/codex/tasks/task_e_68ace849ba508328b9779a727fc6c785