### PR TITLE
Restrict file uploads and enforce size limits

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, UploadFile, File
+from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.responses import HTMLResponse
 from typing import List
 
@@ -10,6 +10,13 @@ from .control_mapper import map_controls as perform_control_mapping
 from .ui import upload_form
 from . import utils
 from .validation import validate_input
+
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+ALLOWED_MIME_TYPES = {
+    "application/pdf",
+    "text/plain",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+}
 
 app = FastAPI(title="DocuSec API")
 
@@ -31,11 +38,19 @@ def root() -> dict:
 async def ingest_document(file: UploadFile = File(...)) -> dict:
     """Upload a document, chunk it, embed it and build the RAG pipeline."""
     global vectorstore, rag_chain
-    text = read_file(await file.read())
+
+    if file.content_type not in ALLOWED_MIME_TYPES:
+        raise HTTPException(status_code=400, detail="Unsupported file type.")
+
+    contents = await file.read()
+    if len(contents) > MAX_FILE_SIZE:
+        raise HTTPException(status_code=413, detail="File too large. Limit 10MB.")
+
+    text = read_file(contents)
     try:
         validate_input(text)
     except ValueError as err:
-        return {"error": str(err)}
+        raise HTTPException(status_code=400, detail=str(err))
     chunks, metadatas = chunk_document(text)
     vectorstore = embed_and_store(chunks, metadatas)
     rag_chain = build_rag(vectorstore)

--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,13 @@ from app.validation import validate_input
 # Streamlit frontend reusing core FastAPI logic
 # This app leverages existing ingestion, RAG, and control mapping functions.
 
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+ALLOWED_MIME_TYPES = {
+    "application/pdf",
+    "text/plain",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+}
+
 # Initialize session state
 if "vectorstore" not in st.session_state:
     st.session_state.vectorstore = None
@@ -42,19 +49,24 @@ if page == "Ingest Policy Document":
     uploaded_file = st.file_uploader("Upload a document", type=["pdf", "docx", "txt"])
     policy_name = st.text_input("Policy name")
     if uploaded_file is not None and policy_name and st.button("Ingest"):
-        text = read_file(uploaded_file.read())
-        try:
-            validate_input(text)
-        except ValueError as err:
-            st.error(str(err))
+        if uploaded_file.type not in ALLOWED_MIME_TYPES:
+            st.error("Unsupported file type.")
+        elif uploaded_file.size > MAX_FILE_SIZE:
+            st.error("File too large. Limit 10MB.")
         else:
-            chunks, metadatas = chunk_document(text)
-            st.session_state.vectorstore = embed_and_store(chunks, metadatas)
-            save_vectorstore(st.session_state.vectorstore, policy_name)
-            st.session_state.rag_chain = build_rag(st.session_state.vectorstore)
-            st.success(
-                f"Document ingested with {len(chunks)} chunks and saved as '{policy_name}'."
-            )
+            text = read_file(uploaded_file.read())
+            try:
+                validate_input(text)
+            except ValueError as err:
+                st.error(str(err))
+            else:
+                chunks, metadatas = chunk_document(text)
+                st.session_state.vectorstore = embed_and_store(chunks, metadatas)
+                save_vectorstore(st.session_state.vectorstore, policy_name)
+                st.session_state.rag_chain = build_rag(st.session_state.vectorstore)
+                st.success(
+                    f"Document ingested with {len(chunks)} chunks and saved as '{policy_name}'."
+                )
 
 elif page == "Interrogate Policy":
     st.header("Ask a Question")
@@ -80,13 +92,18 @@ elif page == "Control Frameworks":
         "Upload a framework CSV", type=["csv"]
     )
     if uploaded_csv is not None and st.button("Upload CSV"):
-        try:
-            count = store_csv_in_db(uploaded_csv.getvalue())
-            st.success(f"Stored {count} controls.")
-        except ValueError as err:
-            st.warning(str(err))
-        except Exception as err:
-            st.error(f"Failed to process CSV: {err}")
+        if uploaded_csv.type != "text/csv":
+            st.error("Unsupported file type.")
+        elif uploaded_csv.size > MAX_FILE_SIZE:
+            st.error("File too large. Limit 10MB.")
+        else:
+            try:
+                count = store_csv_in_db(uploaded_csv.getvalue())
+                st.success(f"Stored {count} controls.")
+            except ValueError as err:
+                st.warning(str(err))
+            except Exception as err:
+                st.error(f"Failed to process CSV: {err}")
         st.json(fetch_controls())
 
 elif page == "Framework Coverage":

--- a/app/validation.py
+++ b/app/validation.py
@@ -2,8 +2,8 @@ import re
 
 # Patterns that indicate potential prompt/SQL/code injection
 _PROHIBITED_PATTERNS = {
-    #"SQL keywords": r"(?i)\b(SELECT|INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|REPLACE|TRUNCATE|UNION|EXECUTE|EXEC)\b",
-    #"SQL comment": r"(--|/\*|\*/)",
+    "SQL keywords": r"(?i)\b(SELECT|INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|REPLACE|TRUNCATE|UNION|EXECUTE|EXEC)\b",
+    "SQL comment": r"(--|/\*|\*/)",
     "Script tag": r"(?i)<script.*?>.*?</script>",
     "Executable code": r"(?i)\b(import|exec|eval|subprocess|os\.system|os\.popen)\b",
 }

--- a/tests/test_rag_api.py
+++ b/tests/test_rag_api.py
@@ -8,8 +8,9 @@ fastapi_stub = types.ModuleType("fastapi")
 
 
 class UploadFile:
-    def __init__(self, data: bytes):
+    def __init__(self, data: bytes, content_type: str = "text/plain"):
         self._data = data
+        self.content_type = content_type
 
     async def read(self) -> bytes:  # noqa: D401
         return self._data
@@ -39,6 +40,13 @@ class FastAPI:
 fastapi_stub.FastAPI = FastAPI
 fastapi_stub.UploadFile = UploadFile
 fastapi_stub.File = File
+class HTTPException(Exception):
+    def __init__(self, status_code: int, detail: str):  # noqa: D401, ANN001
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+fastapi_stub.HTTPException = HTTPException
 responses_stub = types.ModuleType("fastapi.responses")
 responses_stub.HTMLResponse = str
 sys.modules["fastapi"] = fastapi_stub


### PR DESCRIPTION
## Summary
- Validate uploaded document type and size in FastAPI, returning HTTP errors for unsupported types or files over 10MB.
- Enforce matching checks in the Streamlit UI for document and CSV uploads, displaying user-friendly error messages.
- Restore SQL keyword and comment detection in `validate_input` to keep validation comprehensive.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ace8666c808328ae0d3636e90b1f75