### PR TITLE
Secure vectorstore loading

### DIFF
--- a/app/embeddings.py
+++ b/app/embeddings.py
@@ -1,30 +1,33 @@
-from typing import List, Dict, Any
+"""Utilities for working with policy embeddings and vector stores."""
+
+from __future__ import annotations
+
+from typing import List, Dict, Any, BinaryIO
 from pathlib import Path
+import pickle
 
 from .utils import trace
 
 try:  # pragma: no cover - optional community dependency
     from langchain.embeddings import OpenAIEmbeddings
     from langchain.vectorstores import FAISS
+    import faiss
+    from langchain_community.docstore.in_memory import InMemoryDocstore
+    from langchain_core.documents.base import Document
 except Exception:  # pragma: no cover - executed only when packages missing
     OpenAIEmbeddings = None  # type: ignore[assignment]
     FAISS = None  # type: ignore[assignment]
+    faiss = None  # type: ignore[assignment]
+    InMemoryDocstore = None  # type: ignore[assignment]
+    Document = None  # type: ignore[assignment]
+
 
 VECTORSTORE_DIR = Path("vector_store")
 
 
 def embed_and_store(texts: List[str], metadatas: List[Dict[str, Any]] | None = None):
-    """Create embeddings for text chunks and store them in a FAISS vector store.
+    """Create embeddings for text chunks and store them in a FAISS vector store."""
 
-    Args:
-        texts: The textual chunks to embed.
-        metadatas: Optional list of metadata dictionaries to associate with each
-            text.  When provided, the metadata at index ``i`` will be stored
-            alongside ``texts[i]`` in the resulting vector store.
-
-    Returns:
-        A FAISS vector store containing the embedded texts and their metadata.
-    """
     if OpenAIEmbeddings is None or FAISS is None:
         raise ImportError("LangChain community embeddings/vectorstores are unavailable")
     with trace(
@@ -39,13 +42,7 @@ def embed_and_store(texts: List[str], metadatas: List[Dict[str, Any]] | None = N
 def save_vectorstore(
     vectorstore: Any, name: str, base_dir: Path | str = VECTORSTORE_DIR
 ) -> None:
-    """Persist a vector store to disk under a given name.
-
-    Args:
-        vectorstore: The FAISS vector store instance to persist.
-        name: Identifier for the stored policy.
-        base_dir: Directory where policy vector stores are maintained.
-    """
+    """Persist a vector store to disk under a given name."""
 
     safe_name = Path(name).name
     path = Path(base_dir) / safe_name
@@ -62,19 +59,52 @@ def list_vectorstores(base_dir: Path | str = VECTORSTORE_DIR) -> List[str]:
     return sorted([p.name for p in path.iterdir() if p.is_dir()])
 
 
-def load_vectorstore(name: str, base_dir: Path | str = VECTORSTORE_DIR):
-    """Load a previously saved vector store by name."""
+def _safe_load_vectorstore_data(file_obj: BinaryIO):
+    """Safely deserialize docstore and mapping using a restricted unpickler."""
 
-    if OpenAIEmbeddings is None or FAISS is None:
-        raise ImportError(
-            "LangChain community embeddings/vectorstores are unavailable"
-        )
+    if InMemoryDocstore is None or Document is None:
+        raise ImportError("LangChain community docstore classes are unavailable")
+
+    class SafeUnpickler(pickle.Unpickler):  # type: ignore[misc]
+        def find_class(self, module: str, name: str):  # noqa: D401
+            allowed = {
+                (
+                    "langchain_community.docstore.in_memory",
+                    "InMemoryDocstore",
+                ): InMemoryDocstore,
+                (
+                    "langchain_core.documents.base",
+                    "Document",
+                ): Document,
+            }
+            if module == "builtins":
+                import builtins
+
+                return getattr(builtins, name)
+            if (module, name) in allowed:
+                return allowed[(module, name)]
+            raise pickle.UnpicklingError(f"global '{module}.{name}' is forbidden")
+
+    docstore, index_to_docstore_id = SafeUnpickler(file_obj).load()
+    if not (
+        isinstance(docstore, InMemoryDocstore)
+        and isinstance(index_to_docstore_id, dict)
+    ):
+        raise ValueError("Unexpected data in vector store pickle")
+    return docstore, index_to_docstore_id
+
+
+def load_vectorstore(name: str, base_dir: Path | str = VECTORSTORE_DIR):
+    """Load a previously saved vector store by name without unsafe pickle use."""
+
+    if OpenAIEmbeddings is None or FAISS is None or faiss is None:
+        raise ImportError("LangChain community embeddings/vectorstores are unavailable")
+
     safe_name = Path(name).name
     path = Path(base_dir) / safe_name
     embeddings = OpenAIEmbeddings()
-    # Explicitly disable dangerous deserialization to avoid executing
-    # arbitrary code when loading persisted vector stores.
-    return FAISS.load_local(
-        str(path), embeddings, allow_dangerous_deserialization=False
-    )
+    index = faiss.read_index(str(path / "index.faiss"))
+    with open(path / "index.pkl", "rb") as f:
+        docstore, index_to_docstore_id = _safe_load_vectorstore_data(f)
+    return FAISS(embeddings, index, docstore, index_to_docstore_id)
 

--- a/app/validation.py
+++ b/app/validation.py
@@ -2,8 +2,8 @@ import re
 
 # Patterns that indicate potential prompt/SQL/code injection
 _PROHIBITED_PATTERNS = {
-    #"SQL keywords": r"(?i)\b(SELECT|INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|REPLACE|TRUNCATE|UNION|EXECUTE|EXEC)\b",
-    #"SQL comment": r"(--|/\*|\*/)",
+    "SQL keywords": r"(?i)\b(SELECT|INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|REPLACE|TRUNCATE|UNION|EXECUTE|EXEC)\b",
+    "SQL comment": r"(--|/\*|\*/)",
     "Script tag": r"(?i)<script.*?>.*?</script>",
     "Executable code": r"(?i)\b(import|exec|eval|subprocess|os\.system|os\.popen)\b",
 }


### PR DESCRIPTION
## Summary
- implement restricted unpickler and manual FAISS index loading
- validate input against SQL keywords and comments
- adjust tests for safe vectorstore loading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acf064b5948328a6e77a0c7f47e9cc