### PR TITLE
Normalize policy text encoding before vector storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Designed for development in **GitHub Codespaces** using **Python 3.10+**, **Stre
 
 ## 🎯 Key Features
 
-- ✅ Upload and parse policy documents (PDF, DOCX, TXT)
+- ✅ Upload and parse policy documents (PDF, DOCX, TXT) with automatic encoding normalization
 - ✅ Embed and persist policy content in FAISS vector stores
 - ✅ Load and extend security frameworks stored in SQLite
 - ✅ Build framework vector stores and check policy coverage

--- a/app/ingestion.py
+++ b/app/ingestion.py
@@ -5,9 +5,29 @@ from typing import Callable, Dict, List, Tuple
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 import re
 
+try:  # pragma: no cover - optional dependency
+    from charset_normalizer import from_bytes
+except Exception:  # pragma: no cover - library may be absent
+    from_bytes = None
+
 
 def read_file(data: bytes) -> str:
-    """Decode raw file bytes into text."""
+    """Decode raw file bytes into text using detected encoding.
+
+    The function attempts to detect the correct encoding of ``data`` using
+    :mod:`charset_normalizer`.  If detection fails or the library is not
+    available, the bytes are decoded as UTF-8 with errors ignored.  The
+    resulting string is always valid Unicode suitable for storing in the
+    vector store.
+    """
+
+    if from_bytes is not None:
+        try:
+            result = from_bytes(data).best()
+            if result is not None:
+                return str(result)
+        except Exception:
+            pass
     return data.decode("utf-8", errors="ignore")
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from embeddings import (
 from rag_pipeline import build_rag, answer_query
 from framework_loader import load_frameworks
 from control_mapper import check_framework_coverage
+from utils import ensure_utf8
 from db import fetch_controls, store_csv_in_db
 from validation import validate_input
 
@@ -113,7 +114,9 @@ elif page == "Framework Coverage":
                         "Framework": c["framework_title"],
                         "Control Number": c["control_number"],
                         "Control Text": c["control_language"],
-                        "Policy Excerpts": "\n\n".join(c["policy_excerpts"]),
+                        "Policy Excerpts": "\n\n".join(
+                            ensure_utf8(e) for e in c["policy_excerpts"]
+                        ),
                     }
                     for c in coverage
                 ]

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from typing import Any
 
 try:  # pragma: no cover - optional dependency
     from langsmith.run_helpers import trace  # type: ignore[import]
@@ -11,4 +12,35 @@ except Exception:  # pragma: no cover - executed when langsmith missing
 def health() -> dict:
     """Simple health helper used by the API."""
     return {"status": "healthy"}
+
+
+try:  # pragma: no cover - optional dependency
+    from charset_normalizer import from_bytes as _from_bytes
+except Exception:  # pragma: no cover - executed when library missing
+    _from_bytes = None
+
+
+def ensure_utf8(text: Any) -> str:
+    """Return ``text`` as a UTF-8 encoded string.
+
+    ``text`` may be raw bytes from a vector store or any object that can be
+    stringified. Bytes are decoded using :mod:`charset_normalizer` when
+    available, falling back to UTF-8 with ``errors="ignore"``. Non-string
+    objects are coerced to strings and re-encoded as UTF-8 to strip any invalid
+    characters.
+    """
+
+    if isinstance(text, bytes):
+        if _from_bytes is not None:
+            try:
+                result = _from_bytes(text).best()
+                if result is not None:
+                    return str(result)
+            except Exception:
+                pass
+        return text.decode("utf-8", errors="ignore")
+
+    if not isinstance(text, str):
+        text = str(text)
+    return text.encode("utf-8", errors="ignore").decode("utf-8", errors="ignore")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ langchain-community
 fastapi
 tiktoken
 langsmith
+charset-normalizer

--- a/tests/test_encoding_normalization.py
+++ b/tests/test_encoding_normalization.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from app.ingestion import read_file
+from app.utils import ensure_utf8
+
+
+def test_read_file_detects_cp1252_encoding():
+    text = "Smart quotes: “Hello” and euro sign €"
+    data = text.encode("cp1252")
+    assert read_file(data) == text
+
+
+def test_ensure_utf8_normalizes_bytes():
+    text = "Smart quotes: “Hello” and euro sign €"
+    data = text.encode("cp1252")
+    assert ensure_utf8(data) == text


### PR DESCRIPTION
## Summary
- Decode uploaded policy bytes with charset-normalizer before ingestion
- Add charset-normalizer dependency
- Test encoding normalization with CP1252 sample
- Document automatic encoding normalization in key features
- Decode vector store policy excerpts as UTF-8 before displaying coverage table

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acce6827e48328976d596cfbc1b765