### PR TITLE
feat: support PDF and DOCX ingestion

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -107,7 +107,11 @@ async def ingest_document(
     if len(contents) > MAX_FILE_SIZE:
         raise HTTPException(status_code=413, detail="File too large. Limit 10MB.")
 
-    text = read_file(contents)
+    text = read_file(
+        contents,
+        filename=getattr(file, "filename", None),
+        mime_type=getattr(file, "content_type", None),
+    )
     try:
         validate_input(text)
     except ValueError as err:

--- a/app/main.py
+++ b/app/main.py
@@ -56,7 +56,11 @@ if page == "Ingest Policy Document":
         elif uploaded_file.size > MAX_FILE_SIZE:
             st.error("File too large. Limit 10MB.")
         else:
-            text = read_file(uploaded_file.read())
+            text = read_file(
+                uploaded_file.read(),
+                filename=uploaded_file.name,
+                mime_type=uploaded_file.type,
+            )
             try:
                 validate_input(text)
             except ValueError as err:

--- a/app/validation.py
+++ b/app/validation.py
@@ -2,8 +2,8 @@ import re
 
 # Patterns that indicate potential prompt/SQL/code injection
 _PROHIBITED_PATTERNS = {
-    #"SQL keywords": r"(?i)\b(SELECT|INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|REPLACE|TRUNCATE|UNION|EXECUTE|EXEC)\b",
-    #"SQL comment": r"(--|/\*|\*/)",
+    "SQL keywords": r"(?i)\b(SELECT|INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|REPLACE|TRUNCATE|UNION|EXECUTE|EXEC)\b",
+    "SQL comment": r"(--|/\*|\*/)",
     "Script tag": r"(?i)<script.*?>.*?</script>",
     "Executable code": r"(?i)\b(import|exec|eval|subprocess|os\.system|os\.popen)\b",
 }

--- a/tests/test_binary_ingestion.py
+++ b/tests/test_binary_ingestion.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+import io
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app.ingestion import read_file
+
+
+def test_read_file_pdf_docx(tmp_path):
+    # create a simple PDF
+    try:
+        import fitz  # PyMuPDF
+    except Exception:
+        import pytest
+        pytest.skip("PyMuPDF not available")
+    pdf_path = tmp_path / "sample.pdf"
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "Hello PDF")
+    doc.save(pdf_path)
+    data = pdf_path.read_bytes()
+    assert "Hello PDF" in read_file(data, filename="sample.pdf")
+
+    # create a simple DOCX
+    try:
+        from docx import Document
+    except Exception:
+        import pytest
+        pytest.skip("python-docx not available")
+    d = Document()
+    d.add_paragraph("Hello DOCX")
+    docx_path = tmp_path / "sample.docx"
+    d.save(docx_path)
+    data = docx_path.read_bytes()
+    assert "Hello DOCX" in read_file(data, filename="sample.docx")


### PR DESCRIPTION
## Summary
- parse PDF and DOCX uploads via PyMuPDF and python-docx
- forward filename and MIME type when reading uploads
- harden input validation against SQL
- add tests for PDF and DOCX ingestion

## Testing
- `pytest`
- `python - <<'PY'
from app.ingestion import chunk_document
from app.embeddings import embed_and_store, save_vectorstore
text='Policy Title\n\nThis is a sample policy content.'
chunks, metas = chunk_document(text)
try:
    vs = embed_and_store(chunks, metas)
    save_vectorstore(vs, 'SamplePolicy')
    print('re-ingested')
except Exception as e:
    print('re-ingest failed:', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68acf8377a1483289ccd7cde4e84ccde