### PR TITLE
Rank policy excerpts and limit to three per control

### DIFF
--- a/tests/test_framework_coverage.py
+++ b/tests/test_framework_coverage.py
@@ -69,3 +69,36 @@ def test_check_framework_coverage_metadata_text():
     results = check_framework_coverage(store, controls, k=1)
     assert results[0]["policy_excerpts"] == ["text for Requirement text"]
     assert store.queries == [("Requirement text", 1)]
+
+
+class DummyScoreStore:
+    def __init__(self) -> None:
+        self.queries = []
+
+    def similarity_search_with_relevance_scores(self, query: str, k: int = 4):
+        self.queries.append((query, k))
+        return [
+            (DummyDoc(f"low1: {query}"), 0.1),
+            (DummyDoc(f"high1: {query}"), 0.9),
+            (DummyDoc(f"low2: {query}"), 0.2),
+            (DummyDoc(f"mid: {query}"), 0.5),
+            (DummyDoc(f"high2: {query}"), 0.8),
+        ]
+
+
+def test_check_framework_coverage_limits_and_ranks():
+    store = DummyScoreStore()
+    controls = [
+        {
+            "framework_title": "ISO",
+            "control_number": "1",
+            "control_language": "Requirement text",
+        }
+    ]
+    results = check_framework_coverage(store, controls, k=5)
+    assert results[0]["policy_excerpts"] == [
+        "high1: Requirement text",
+        "high2: Requirement text",
+        "mid: Requirement text",
+    ]
+    assert store.queries == [("Requirement text", 5)]


### PR DESCRIPTION
## Summary
- Limit each control to at most three policy excerpts
- Rank retrieved excerpts by relevance score when available
- Add tests covering ranking behavior and excerpt limit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad0fab4bb0832888f2b505184ace3f